### PR TITLE
Fixes a table name misnaming

### DIFF
--- a/db/db.sql
+++ b/db/db.sql
@@ -2,7 +2,7 @@ CREATE EXTENSION IF NOT EXISTS "uuid-ossp";
 
 DROP TABLE IF EXISTS public.planning_application_documents CASCADE;
 
-DROP TABLE IF EXISTS public.planning_application_polygons CASCADE;
+DROP TABLE IF EXISTS public.planning_application_geometries CASCADE;
 
 DROP TABLE IF EXISTS public.planning_applications CASCADE;
 


### PR DESCRIPTION
In the drop table in ./db/db.sql planning_application_geometries is referred to as planning_application_polygons.

This causes the drop table command to error. Simple fix to rename.